### PR TITLE
data.iteritems given a dictionary to iterate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open('LICENSE') as f:
 
 setup(
     name='stackdriver',
-    version='0.2',
+    version='0.2.1',
     description='Stackdriver Client APIs for Python',
     long_description=readme + '\n\n', # TODO: add a history file
     author='John (J5) Palmieri',

--- a/stackdriver/stackapi.py
+++ b/stackdriver/stackapi.py
@@ -206,7 +206,7 @@ class AnonStackObject(AnonStackInterface, dict):
             raise TypeError('Object must be a dictionary')
 
         # copy all items in dict
-        for key, value in data.iteritems():
+        for key, value in data[0].iteritems():
             self[key] = value
 
         super(AnonStackObject, self).__init__(rest_class, client)
@@ -238,7 +238,7 @@ class AnonStackObject(AnonStackInterface, dict):
         data = self._unwind_result(resp)
 
         # merge response in
-        for key, value in data.iteritems():
+        for key, value in data[0].iteritems():
             self[key] = value
 
         return self
@@ -254,7 +254,7 @@ class AnonStackObject(AnonStackInterface, dict):
         data = self._unwind_result(resp)
 
         # merge response in
-        for key, value in data.iteritems():
+        for key, value in data[0].iteritems():
             self[key] = value
 
         return self
@@ -298,7 +298,7 @@ class AnonStackObject(AnonStackInterface, dict):
         data = self._unwind_result(resp)
 
         # merge response in
-        for key, value in data.iteritems():
+        for key, value in data[0].iteritems():
             self[key] = value
 
         return self

--- a/stackdriver/stackapi.py
+++ b/stackdriver/stackapi.py
@@ -206,7 +206,7 @@ class AnonStackObject(AnonStackInterface, dict):
             raise TypeError('Object must be a dictionary')
 
         # copy all items in dict
-        for key, value in data[0].iteritems():
+        for key, value in data.iteritems():
             self[key] = value
 
         super(AnonStackObject, self).__init__(rest_class, client)


### PR DESCRIPTION
data is a list object, and when merging in it was called with
.iteritems() but list objects don't have .iteritems() and this
 fails when called. data[0] is the first dictionary returned from
 the stackdriver response. This corrects the bug.
